### PR TITLE
Fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-# 
+# Phillip Domann, Shad, Melanie, Matt
 # mascxxxx
+# Team Idaho
 # prog1
 # CS530, Spring 2016
 

--- a/file_parse_exception.h
+++ b/file_parse_exception.h
@@ -1,11 +1,14 @@
-/*  file_parse_exception.h
-    Exception class for file_parser
-    CS530 Spring 2016
-    Alan Riggins
+/* Phillip Domann, Shad, Melanie, Matt
+   mascxxxx
+   Team Idaho
+   prog1
+   CS530, Spring 2016
 */
 
 #ifndef FILE_PARSE_EXCEPTION_H
 #define FILE_PARSE_EXCEPTION_H
+
+#include <sstream>
 
 using namespace std;
 
@@ -16,8 +19,8 @@ public:
         message = s;
     }
     
-    file_parse_exception(string s, int lineno, string token) {
-        message = "Line "+itos(lineno)+": "+token+"\n"+s;
+    file_parse_exception(string s, int lineno, string line) {
+        message = "Line "+itos(lineno)+": "+line+"\n"+s;
     }
 
     file_parse_exception() {

--- a/file_parser.cc
+++ b/file_parser.cc
@@ -1,52 +1,48 @@
+/* Phillip Domann, Shad, Melanie, Matt
+   mascxxxx
+   Team Idaho
+   prog1
+   CS530, Spring 2016
+*/
+
 #include <algorithm>
 #include <cstdlib>
-#include <iomanip>
-#include <algorithm>
-#include <iostream>
 #include <fstream>
-#include <string>
+#include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <vector>
-#include <iomanip>
 #include "file_parser.h"
 #include "file_parse_exception.h"
 
 using namespace std;
 
-/**
- * Constrctor
- */
+const char* file_parser::delimiters = " \t";
+
 file_parser::file_parser(string filename){
     this->filename = filename;
-    source = NULL;
 }
 
-/**
- * Destructor
- */
 file_parser::~file_parser(){
-    delete source;
 }
 
-/**
- * Reads a file by line,
- */
 void file_parser::read_file(){
-    source = get_file_contents();
+    if (!container.empty()) {
+        container.clear();
+    }
+    lineno = 0;
+    string source = get_file_contents();
 
-    istringstream sstream (*source);
+    istringstream sstream (source);
     string str;
     while (getline(sstream, str)) {
-        tokenizer toke (str);
-        struct line tstruct = toke.tokens();
+        struct line tstruct = tokenize(str);
         container.push_back(tstruct);
     }
 }
 
-/**
- *  
- */
 string file_parser::get_token(unsigned int row, unsigned int column){
     try {
         switch (column) {
@@ -59,46 +55,36 @@ string file_parser::get_token(unsigned int row, unsigned int column){
             case 3:
                 return container.at(row).getcomment();
             default:
-                throw file_parse_exception("Get token column is out of bounds, must be between 0 and 3");
+                throw file_parse_exception("Get token column is out of bounds, "
+                    "must be between 0 and 3.");
         }
     } catch (out_of_range &oor) {
-        throw file_parse_exception("Get token row is out of bounds, must be between 0 and size()-1");
+        throw file_parse_exception("Get token row is out of bounds, "
+            "must be between 0 and size()-1.");
     }
 }
 
-/**
- * Prints the contents of the file to stdout
- */
 void file_parser::print_file(){
 	vector<line>::iterator iter;
 	for ( iter = container.begin() ; iter < container.end() ; iter++ ){
-	cout.setf(ios::left);
-	cout.width(16);
-	cout << iter->getlabel() << setw(16) << iter->getopcode() << setw(16) << iter->getoperand() << setw(36) << iter->getcomment() << endl;
+        cout.setf(ios::left);
+        cout.width(16);
+        cout << iter->getlabel() << setw(16) << iter->getopcode() << setw(16)
+             << iter->getoperand() << setw(36) << iter->getcomment() << "\n";
 	}
 }
 
-/**
- * Returns the number of lines of the file.
- */
 int file_parser::size(){
 	return (int)container.size();
 }
 
-/**
- * Returns a pointer to a string with the file's contents
- */
-
-const string* file_parser::get_file_contents() {
-    if (source != NULL) {
-        delete source;
-    }
-    
+string file_parser::get_file_contents() {
     ifstream stream;
     stream.open(filename.c_str(), ios::in);
     
     if (!stream.is_open()) {
-        throw file_parse_exception("Could not open file "+filename+". Check that the file exists or was properly entered.");
+        throw file_parse_exception("Could not open file "+filename
+            +". Check that the file exists or was properly entered.");
     }
     stream.seekg(0, ios::end);
     long long filesize = stream.tellg();
@@ -108,25 +94,19 @@ const string* file_parser::get_file_contents() {
     buffer = new (nothrow) char[filesize+1];
     if (buffer == NULL) {
         stream.close();
-        throw file_parse_exception("Could not allocate memory to read source file.");
+        throw file_parse_exception(
+            "Could not allocate memory to read source file.");
     }
     stream.read(buffer, filesize);
     buffer[filesize] = '\0';
-    string* contents = new (nothrow) string(buffer);
+    string contents (buffer);
     
     stream.close();
     delete[] buffer;
     return contents;
 }
 
-const char* file_parser::tokenizer::delimiters = " \t";
-
-file_parser::tokenizer::tokenizer(const string& str) {
-    this->str = str;
-}
-
-struct file_parser::line file_parser::tokenizer::tokens() {
-    static int lineno = 0;
+struct file_parser::line file_parser::tokenize(const string& str) {
     ++lineno;
     column previous = none;
     struct line tokenstruct;
@@ -136,7 +116,7 @@ struct file_parser::line file_parser::tokenizer::tokens() {
     first = str.find_first_of(delimiters, last);
 retoken:
     while (first != string::npos || last != string::npos) {
-        ptrdiff_t quotes;
+        ptrdiff_t nquotes;
         string token = str.substr(last, first-last);
         if (iscomment(token)) {
             token = str.substr(last, string::npos);
@@ -148,28 +128,30 @@ retoken:
                 previous = label;
                 goto next_token;
             } else {
-                throw file_parse_exception("Invalid label, a label starts with a letter and contains only alphanumeric characters.",
-                    lineno, str);
+                throw file_parse_exception("Invalid label at beginning of line."
+                "\nA label starts with a letter and contains only alphanumeric "
+                "characters.", lineno, str);
             }
         }
-        quotes = count(token.begin(), token.end(), '\'');
-        if (quotes%2) {
+        nquotes = count(token.begin(), token.end(), '\'');
+        if (nquotes%2) {
             if (first == string::npos) {
-                throw file_parse_exception("Check that quoted characters are correctly terminated.", lineno, str);
+                throw file_parse_exception("Check that quoted characters are "
+                "correctly terminated.", lineno, str);
             }
             first = str.find_first_of(delimiters, first+1);
             goto retoken;
         }
-        if ((previous == none) | (previous == label)) {
+        if (previous == none || previous == label) {
             tokenstruct.setopcode(token);
             previous = opcode;
         } else if (previous == opcode) {
             tokenstruct.setoperand(token);
             previous = operand;
         } else {
-            throw file_parse_exception("There are too many instructions."
-                "\nProper format may include only the following: label opcode operand(s) .comment",
-                lineno, str);
+            throw file_parse_exception("There are too many statements."
+                "\nProper format may include only the following: "
+                "label opcode operand(s) .comment", lineno, str);
         }
     next_token:
         last = str.find_first_not_of(delimiters, first);

--- a/file_parser.h
+++ b/file_parser.h
@@ -1,14 +1,16 @@
-/*  file_parser.h
-    CS530, Spring 2016
+/* Phillip Domann, Shad, Melanie, Matt
+   mascxxxx
+   Team Idaho
+   prog1
+   CS530, Spring 2016
 */
+
 #ifndef FILE_PARSER_H
 #define FILE_PARSER_H
 
 #include <string>
 #include <vector>
 #include <ctype.h>
-#include <sstream>
-#include <stdio.h>
 #include <stdbool.h>
 
 using namespace std;
@@ -44,67 +46,66 @@ class file_parser {
 
         // returns the number of lines in the source code file
         int size();
-        
 
     private:
-        // your variables and private methods go here
-    struct line{
-        string label,
-        opcode,
-        operand,
-        comment;
-        line(){
-            label = "";
-            opcode = "";
-            operand = "";
-            comment = "";
-        }
-        string getlabel(){
-            return label;
-        }
-        string getopcode(){
-            return opcode;
-        }
-        string getoperand(){
-            return operand;
-        }
-        string getcomment(){
-            return comment;
-        }
-        void setlabel(string lab){
-            if(lab.length() > 7)
-                lab.resize(8);
-            label = lab;
-        }
-        void setopcode(string op){
-            opcode = op;
-        }
-        void setoperand(string oper){
-            operand = oper;
-        }
-        void setcomment(string com){
-            comment = com; 
-        }
-    };
     
-    vector<line> container;
-    string filename;
-    const string* source;
-    
-    // Reads the entire source file into memory, throws an error if the
-    // file cannot be opened or memory cannot be allocated
-    const string* get_file_contents();
-        
-    class tokenizer {
-        
-    public:
-        tokenizer(const string&);
-        struct line tokens();
-    private:
-        string str;
-        enum column {none, label, opcode, operand, comment};
+        string filename;
+        int lineno;
         static const char* delimiters;
-        
+        enum column {none, label, opcode, operand, comment};
+
+        struct line{
+            string label,
+            opcode,
+            operand,
+            comment;
+            line(){
+                label = "";
+                opcode = "";
+                operand = "";
+                comment = "";
+            }
+            
+            string getlabel(){
+                return label;
+            }
+            string getopcode(){
+                return opcode;
+            }
+            string getoperand(){
+                return operand;
+            }
+            string getcomment(){
+                return comment;
+            }
+            void setlabel(string lab){
+                if(lab.length() > 7)
+                    lab.resize(8);
+                label = lab;
+            }
+            void setopcode(string op){
+                opcode = op;
+            }
+            void setoperand(string oper){
+                operand = oper;
+            }
+            void setcomment(string com){
+                comment = com;
+            }
+        };
+
+        // Container for token rows
+        vector<line> container;
+    
+        // Reads the entire source file into memory, throws an error if the
+        // file cannot be opened or memory cannot be allocated
+        string get_file_contents();
+    
+        // Breaks a source line into tokens and returns a token struct
+        // Throws errors if the line does not meet proper format
+        struct line tokenize(const string&);
+
+        // Verifies that a label has proper format
         bool islabel(string islab){
             if(!isalpha(islab[0]))
                 return false;
@@ -114,14 +115,14 @@ class file_parser {
             }
             return true;
         }
-        
+    
+        // Checks if a token is a comment
         bool iscomment(string iscom){
             if(iscom[0] != '.')
                 return false;
             return true;
         }
         
-    };
 };
 
 #endif

--- a/parsesicxe.cpp
+++ b/parsesicxe.cpp
@@ -1,8 +1,9 @@
-/*
- * mascxxxx
- * prog1
- * CS530, Spring 2016
- */
+/* Phillip Domann, Shad, Melanie, Matt
+   mascxxxx
+   Team Idaho
+   prog1
+   CS530, Spring 2016
+*/
 
 #include <iostream>
 #include "file_parser.h"
@@ -12,7 +13,7 @@ using namespace std;
 
 int main(int argc, const char *argv[]) {
     if (argc != 2) {
-        cout << "Proper usage is " << argv[0] << " sourcefile.\n";
+        cout << "Proper usage is " << argv[0] << " sourcefile\n";
         return -1;
     }
     
@@ -21,7 +22,7 @@ int main(int argc, const char *argv[]) {
         fp->read_file();
     } catch (file_parse_exception e) {
         cout << e.getMessage() << "\n";
-        return -1;
+        return 1;
     }
 
     fp->print_file();


### PR DESCRIPTION
Need everyone's last name and the turn in account.
Removed comments from .cc and put them in header.
Removed unnecessary headers.
Wrapped the code if it went off the page margins.
Turned the tokenizer into a file_parser method.
Caught the loop error with unclosed quotes.
Removed the use of the file's contents as a pointer b/c they will be lost if read_file() is called multiple times.
Used proper types and variable names.
Better error messages
Compiles on rohan with no errors or warnings.
All four source files are handled properly
